### PR TITLE
Clarify Source & Sinks in the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ You can read more about inhooks in the [launch blog post](https://didil.medium.c
 ![Inhooks Architecture](inhooks-architecture.png?raw=true "Inhooks Architecture")
 
 ### High level overview
-Inhooks listens to HTTP webhooks and saves the messages to Redis. A processing module retrieves the messages and sends them reliably to the defined targets.
+Inhooks consists of two major concepts, Sources and Sinks. A Source is an endpoint for receiving webhooks, and a [Sink](https://en.wikipedia.org/wiki/Sink_(computing)) is a target that receives the webhooks.
+
+Inhooks listens to HTTP webhooks and saves the messages to Redis. A processing module retrieves the messages and sends them reliably to the defined sinks.
 
 ## Features
 - Receive HTTP Webhooks and save them to a Redis database
-- Fanout messages to multiple HTTP targets
+- Fanout messages to multiple HTTP targets (sinks)
 - Fast, concurrent processing
 - Supports delayed processing
 - Supports retries on failure with configurable number of attempts, interval and constant or exponential backoff


### PR DESCRIPTION
The README wasn't using the same terminology as the config. When I arrived at the config section, I was confused as to what a sink was.

If you have the source for the [architecture diagram](https://github.com/didil/inhooks/blob/main/inhooks-architecture.png), I feel it could also benefit from using Sink instead of Target.

---
I found this project from your [post on reddit](https://www.reddit.com/r/selfhosted/comments/s0kkw3/anyone_seen_a_web_hook_relay_or_forwarding_app/laikgwn/). I came to that thread looking for a solution exactly like this. Thanks for sharing it.